### PR TITLE
add name to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "name": "permitio/permit-php",
     "description": "Authorization as a service",
     "keywords": [
         "openapitools",


### PR DESCRIPTION
We didn't have "name" value in the `composer.json` file that led to installation errors. This PR adds the name value.